### PR TITLE
Update toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-10-05"
+channel = "nightly-2025-04-15"

--- a/sqlite3_capi/build.rs
+++ b/sqlite3_capi/build.rs
@@ -14,6 +14,14 @@ fn main() {
     // Tell cargo to invalidate the built crate whenever the wrapper changes
     println!("cargo:rerun-if-changed=wrapper.h");
 
+    let mut target_override: Vec<String> = vec![];
+    if let Ok(t) = env::var("TARGET") {
+        if t == "aarch64-apple-ios-sim" {
+            // Workaround for https://github.com/rust-lang/rust-bindgen/issues/3181
+            target_override.push("--target=arm64-apple-ios-simulator".to_string());
+        }
+    }
+
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for
     // the resulting bindings.
@@ -24,6 +32,7 @@ fn main() {
         // bindings for.
         .header("wrapper.h")
         .clang_arg("-fvisibility=default")
+        .clang_args(target_override)
         .use_core()
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.

--- a/sqlite_nostd/src/lib.rs
+++ b/sqlite_nostd/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![feature(vec_into_raw_parts)]
-#![feature(error_in_core)]
 #![allow(non_camel_case_types)]
 
 mod nostd;


### PR DESCRIPTION
This updates the Rust nightly version to the same version we'll use in the sqlite core extension. It also applies a workaround to allow building `sqlite3_capi` with clang 17 for iOS simulator targets (the target triple in clang has changed and a bindgen fix to adopt that has not been released yet).