### PR TITLE
Expose bindings blobs, parameter names

### DIFF
--- a/sqlite3_capi/src/capi.rs
+++ b/sqlite3_capi/src/capi.rs
@@ -220,6 +220,14 @@ pub fn bind_value(stmt: *mut stmt, c: c_int, v: *mut value) -> c_int {
     unsafe { invoke_sqlite!(bind_value, stmt, c, v) }
 }
 
+pub fn bind_parameter_count(stmt: *mut stmt) -> c_int {
+    unsafe { invoke_sqlite!(bind_parameter_count, stmt) }
+}
+
+pub fn bind_parameter_name(stmt: *mut stmt, c: c_int) -> *const c_char {
+    unsafe { invoke_sqlite!(bind_parameter_name, stmt, c) }
+}
+
 pub fn close(db: *mut sqlite3) -> c_int {
     unsafe { invoke_sqlite!(close, db) }
 }

--- a/sqlite_nostd/src/nostd.rs
+++ b/sqlite_nostd/src/nostd.rs
@@ -762,6 +762,11 @@ impl ManagedStmt {
     }
 
     #[inline]
+    pub fn bind_double(&self, i: i32, val: f64) -> Result<ResultCode, ResultCode> {
+        convert_rc(bind_double(self.stmt, i, val))
+    }
+
+    #[inline]
     pub fn bind_null(&self, i: i32) -> Result<ResultCode, ResultCode> {
         convert_rc(bind_null(self.stmt, i))
     }
@@ -769,6 +774,21 @@ impl ManagedStmt {
     #[inline]
     pub fn clear_bindings(&self) -> Result<ResultCode, ResultCode> {
         convert_rc(clear_bindings(self.stmt))
+    }
+
+    #[inline]
+    pub fn bind_parameter_count(&self) -> c_int {
+        bind_parameter_count(self.stmt)
+    }
+
+    pub fn bind_parameter_name(&self, i: i32) -> Result<Option<&str>, Utf8Error> {
+        let ptr = bind_parameter_name(self.stmt, i);
+        if ptr.is_null() {
+            Ok(None)
+        } else {
+            let name = unsafe { CStr::from_ptr(ptr) };
+            Ok(Some(name.to_str()?))
+        }
     }
 
     #[inline]


### PR DESCRIPTION
This adds the `bind_double` method to bind `f64` values as well as `parameter_count` and `parameter_name`, used to obtain the amount and names of parameters in a prepared statement.