### PR TITLE
Add subtype method on context

### DIFF
--- a/sqlite3_capi/src/capi.rs
+++ b/sqlite3_capi/src/capi.rs
@@ -86,13 +86,6 @@ pub enum Destructor {
     CUSTOM(xDestroy),
 }
 
-#[macro_export]
-macro_rules! strlit {
-    ($s:expr) => {
-        concat!($s, "\0").as_ptr() as *const c_char
-    };
-}
-
 #[cfg(feature = "static")]
 macro_rules! invoke_sqlite {
     ($name:ident, $($arg:expr),*) => {
@@ -111,10 +104,6 @@ macro_rules! invoke_sqlite {
   ($name:ident) => {
     ((*SQLITE3_API).$name.unwrap())()
   };
-}
-
-pub extern "C" fn droprust(ptr: *mut c_void) {
-    unsafe { invoke_sqlite!(free, ptr as *mut c_void) }
 }
 
 #[macro_export]
@@ -166,13 +155,13 @@ pub fn changes64(db: *mut sqlite3) -> int64 {
     unsafe { invoke_sqlite!(changes64, db) }
 }
 
+#[cfg(feature = "static")]
 pub fn shutdown() -> c_int {
-    #[cfg(feature = "static")]
-    unsafe {
-        aliased::shutdown()
-    }
+    unsafe { aliased::shutdown() }
+}
 
-    #[cfg(feature = "loadable_extension")]
+#[cfg(not(feature = "static"))]
+pub fn shutdown() -> c_int {
     0
 }
 

--- a/sqlite3_capi/src/lib.rs
+++ b/sqlite3_capi/src/lib.rs
@@ -2,7 +2,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
-#![feature(concat_idents)]
 
 pub mod bindings {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/sqlite_nostd/src/lib.rs
+++ b/sqlite_nostd/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(vec_into_raw_parts)]
 #![allow(non_camel_case_types)]
 
 mod nostd;


### PR DESCRIPTION
This exposes the `sqlite3_result_subtype` method on the `Context` trait.

I've also removed methods to bind owned values - we don't use them in PowerSync. This allows removing more unstable features from that crate.