### PR TITLE
Support update, commit and rollback hooks

### DIFF
--- a/sqlite3_capi/src/capi.rs
+++ b/sqlite3_capi/src/capi.rs
@@ -69,14 +69,14 @@ mod aliased {
         sqlite3_result_subtype as result_subtype, sqlite3_result_text as result_text,
         sqlite3_result_value as result_value, sqlite3_set_authorizer as set_authorizer,
         sqlite3_set_auxdata as set_auxdata, sqlite3_shutdown as shutdown, sqlite3_sql as sql,
-        sqlite3_step as step, sqlite3_user_data as user_data, sqlite3_value_blob as value_blob,
-        sqlite3_value_bytes as value_bytes, sqlite3_value_double as value_double,
-        sqlite3_value_int as value_int, sqlite3_value_int64 as value_int64,
-        sqlite3_value_pointer as value_pointer, sqlite3_value_subtype as value_subtype,
-        sqlite3_value_text as value_text, sqlite3_value_type as value_type,
-        sqlite3_vtab_collation as vtab_collation, sqlite3_vtab_config as vtab_config,
-        sqlite3_vtab_distinct as vtab_distinct, sqlite3_vtab_nochange as vtab_nochange,
-        sqlite3_vtab_on_conflict as vtab_on_conflict,
+        sqlite3_step as step, sqlite3_update_hook as update_hook, sqlite3_user_data as user_data,
+        sqlite3_value_blob as value_blob, sqlite3_value_bytes as value_bytes,
+        sqlite3_value_double as value_double, sqlite3_value_int as value_int,
+        sqlite3_value_int64 as value_int64, sqlite3_value_pointer as value_pointer,
+        sqlite3_value_subtype as value_subtype, sqlite3_value_text as value_text,
+        sqlite3_value_type as value_type, sqlite3_vtab_collation as vtab_collation,
+        sqlite3_vtab_config as vtab_config, sqlite3_vtab_distinct as vtab_distinct,
+        sqlite3_vtab_nochange as vtab_nochange, sqlite3_vtab_on_conflict as vtab_on_conflict,
     };
 }
 
@@ -559,6 +559,16 @@ pub fn step(stmt: *mut stmt) -> c_int {
 #[inline]
 pub fn user_data(ctx: *mut context) -> *mut c_void {
     unsafe { invoke_sqlite!(user_data, ctx) }
+}
+
+pub type xUpdateHook =
+    unsafe extern "C" fn(*mut c_void, c_int, *const c_char, *const c_char, i64) -> ();
+pub fn update_hook(
+    db: *mut sqlite3,
+    callback: Option<xUpdateHook>,
+    context: *mut c_void,
+) -> *mut c_void {
+    unsafe { invoke_sqlite!(update_hook, db, callback, context) }
 }
 
 pub fn value_text<'a>(arg1: *mut value) -> &'a str {

--- a/sqlite3_capi/src/capi.rs
+++ b/sqlite3_capi/src/capi.rs
@@ -67,9 +67,10 @@ mod aliased {
         sqlite3_result_int as result_int, sqlite3_result_int64 as result_int64,
         sqlite3_result_null as result_null, sqlite3_result_pointer as result_pointer,
         sqlite3_result_subtype as result_subtype, sqlite3_result_text as result_text,
-        sqlite3_result_value as result_value, sqlite3_set_authorizer as set_authorizer,
-        sqlite3_set_auxdata as set_auxdata, sqlite3_shutdown as shutdown, sqlite3_sql as sql,
-        sqlite3_step as step, sqlite3_update_hook as update_hook, sqlite3_user_data as user_data,
+        sqlite3_result_value as result_value, sqlite3_rollback_hook as rollback_hook,
+        sqlite3_set_authorizer as set_authorizer, sqlite3_set_auxdata as set_auxdata,
+        sqlite3_shutdown as shutdown, sqlite3_sql as sql, sqlite3_step as step,
+        sqlite3_update_hook as update_hook, sqlite3_user_data as user_data,
         sqlite3_value_blob as value_blob, sqlite3_value_bytes as value_bytes,
         sqlite3_value_double as value_double, sqlite3_value_int as value_int,
         sqlite3_value_int64 as value_int64, sqlite3_value_pointer as value_pointer,
@@ -237,12 +238,8 @@ pub fn commit_hook(
     db: *mut sqlite3,
     callback: Option<xCommitHook>,
     user_data: *mut c_void,
-) -> Option<xCommitHook> {
-    unsafe {
-        invoke_sqlite!(commit_hook, db, callback, user_data)
-            .as_ref()
-            .map(|p| core::mem::transmute(p))
-    }
+) -> *mut c_void {
+    unsafe { invoke_sqlite!(commit_hook, db, callback, user_data) }
 }
 
 // pub fn mprintf(format: *const i8, ...) -> *mut c_char {
@@ -549,6 +546,15 @@ pub fn sql(s: *mut stmt) -> *const c_char {
 
 pub fn reset(stmt: *mut stmt) -> c_int {
     unsafe { invoke_sqlite!(reset, stmt) }
+}
+
+pub type xRollbackHook = unsafe extern "C" fn(*mut c_void);
+pub fn rollback_hook(
+    db: *mut sqlite3,
+    hook: Option<xRollbackHook>,
+    ctx: *mut c_void,
+) -> *mut c_void {
+    unsafe { invoke_sqlite!(rollback_hook, db, hook, ctx) }
 }
 
 #[inline]

--- a/sqlite_nostd/src/nostd.rs
+++ b/sqlite_nostd/src/nostd.rs
@@ -318,6 +318,8 @@ pub trait Connection {
         user_data: *mut c_void,
     ) -> Result<ResultCode, ResultCode>;
 
+    fn update_hook(&self, callback: Option<xUpdateHook>, ctx: *mut c_void) -> *const c_void;
+
     fn get_autocommit(&self) -> bool;
 }
 
@@ -417,6 +419,10 @@ impl Connection for ManagedConnection {
     #[inline]
     fn get_autocommit(&self) -> bool {
         self.db.get_autocommit()
+    }
+
+    fn update_hook(&self, callback: Option<xUpdateHook>, ctx: *mut c_void) -> *const c_void {
+        self.db.update_hook(callback, ctx)
     }
 
     #[cfg(all(feature = "static", not(feature = "omit_load_extension")))]
@@ -639,6 +645,10 @@ impl Connection for *mut sqlite3 {
 
     fn get_autocommit(&self) -> bool {
         get_autocommit(*self) != 0
+    }
+
+    fn update_hook(&self, callback: Option<xUpdateHook>, ctx: *mut c_void) -> *const c_void {
+        update_hook(*self, callback, ctx)
     }
 }
 


### PR DESCRIPTION
This adds support for update and rollback hooks. It also fixes the definition of commit hooks to properly return the user data pointer instead of the function pointer.